### PR TITLE
added code of conduct from last year

### DIFF
--- a/components/DefaultPage.js
+++ b/components/DefaultPage.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import Page from '../components/Page.js';
+
+const HeaderImage = styled.header`
+    position: relative;
+    z-index: 1;
+    margin: 60px 60px 0 60px;
+    height: calc(100% - 115px);
+
+background: url(static/disclaimer-header.jpg) no-repeat center;
+    background-size: auto 100%;
+`;
+
+const Main = styled.main`
+    display: flex;
+
+    position: relative;
+    z-index: 1;
+
+    margin: 140px 110px 100px 110px;
+
+    color: #fff;
+
+    h2 {
+        font-weight: 100;
+        font-family: Teko;
+        font-size: 48px;
+        line-height: 54px;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+    }
+
+    h3 {
+        font-weight: 100;
+        font-family: Teko;
+        font-size: 28px;
+        line-height: 40px;
+        text-transform: uppercase;
+
+        margin: 60px 0 30px 0;
+    }
+
+    p {
+        color: #ddd;
+        font-size: 16px;
+        line-height: 30px;
+    }
+`;
+
+const HeaderSection = styled.section`
+    margin: 0 67px 0 74px;
+`;
+
+const MainSection = styled.section`
+    p {
+        margin-bottom: 30px;
+    }
+`;
+
+export default class DefaultPage extends React.PureComponent {
+    static propTypes = {
+        header: PropTypes.string.isRequired,
+        article: PropTypes.string.isRequired,
+    };
+
+    render() {
+        return (
+            <Page>
+                <HeaderImage />
+                <Main>
+                    <HeaderSection>
+                        <h2>{this.props.header}</h2>
+                    </HeaderSection>
+                    <MainSection dangerouslySetInnerHTML={{__html: this.props.article}} />
+                </Main>
+            </Page>
+        );
+    }
+}

--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -107,6 +107,7 @@ export default class Navigation extends React.PureComponent {
                 <Lines color="rgba(0, 0, 0, 0.07)" />
                 <ul>
                     <li><Link href="/disclaimer"><a>Disclaimer</a></Link></li>
+                    <li><Link href="/coc"><a>Code of Conduct</a></Link></li>
                     <li><a href="https://blog.agent.sh">Blog</a></li>
                     <li><a href="http://www.2017.agent.sh">AgentConf 2017</a></li>
                 </ul>

--- a/pages/coc.js
+++ b/pages/coc.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import DefaultPage from '../components/DefaultPage';
+
+export default class Disclaimer extends React.Component {
+    render() {
+        const props = {
+            header: 'Code of Conduct',
+            article: `
+                <h3>Be excellent with each other</h3>
+                <p>
+                    All attendees, speakers, sponsors and volunteers at our
+                    conference are required to agree with the following code of
+                    conduct. Organisers will enforce this code throughout the
+                    event. We are expecting cooperation from all participants
+                    to help ensuring a safe environment for everybody. NEED
+                    HELP?
+                </p>
+                <p>
+                    Guntram Bechtold at +43 (664) 35 666 18
+                </p>
+
+                <h3>The quick version</h3>
+                <p>
+                    Our conference is dedicated to providing a harassment-free
+                    conference experience for everyone, regardless of gender,
+                    age, disability, physical appearance, body size, race,
+                    religion (or lack thereof), color, national origin, genetic
+                    information or the like. We do not tolerate harassment of
+                    conference participants in any form. Sexual language and
+                    imagery is not appropriate for any conference venue,
+                    including talks, workshops, parties, Twitter and other
+                    online media. Conference participants violating these rules
+                    may be sanctioned or expelled from the conference without a
+                    refund at the discretion of the conference organisers.
+                </p>
+
+                <h3>The less quick version</h3>
+
+                <p>
+                    Harassment includes offensive verbal comments related to
+                    gender, age, disability, physical appearance, body size,
+                    race, religion, color, national origin, genetic
+                    information, sexual images in public spaces, deliberate
+                    intimidation, stalking, following, harassing photography or
+                    recording, sustained disruption of talks or other events,
+                    inappropriate physical contact, unwelcome sexual attention
+                    and the like.
+                </p>
+                <p>
+                    Participants asked to stop any harassing behavior are
+                    expected to comply immediately.
+                </p>
+                <p>
+                    Sponsors are also subject to the anti-harassment policy. In
+                    particular, sponsors should not use sexualised images,
+                    activities, or other material. Booth staff (including
+                    volunteers) should not use sexualised
+                    clothing/uniforms/costumes, or otherwise create a
+                    sexualised environment.
+                </p>
+                <p>
+                    If a participant engages in harassing behavior, the
+                    conference organisers may take any action they deem
+                    appropriate, including warning the offender or expulsion
+                    from the conference with no refund.
+                </p>
+                <p>
+                    If you are being harassed, notice that someone else is
+                    being harassed, or have any other concerns, please contact
+                    a member of conference staff immediately. Conference staff
+                    can be identified as they'll be wearing branded t-shirts.
+                </p>
+                <p>
+                    Conference staff will be happy to help participants contact
+                    hotel/venue security or local law enforcement, provide
+                    escorts, or otherwise assist those experiencing harassment
+                    to feel safe for the duration of the conference. We value
+                    your attendance.
+                </p>
+                <p>
+                    We expect participants to follow these rules at conference
+                    and workshop venues and conference-related social events.
+                </p>
+            `,
+        };
+
+        return (
+            <DefaultPage {...props} />
+        );
+    }
+}

--- a/pages/disclaimer.js
+++ b/pages/disclaimer.js
@@ -1,112 +1,51 @@
 import React from 'react';
-import styled from 'styled-components';
-import Page from '../components/Page.js';
+import DefaultPage from '../components/DefaultPage';
 
-const HeaderImage = styled.header`
-    position: relative;
-    z-index: 1;
-    margin: 60px 60px 0 60px;
-    height: calc(100% - 115px);
-
-background: url(static/disclaimer-header.jpg) no-repeat center;
-    background-size: auto 100%;
-`;
-
-const Main = styled.main`
-    display: flex;
-
-    position: relative;
-    z-index: 1;
-
-    margin: 140px 110px 100px 110px;
-
-    color: #fff;
-
-    h2 {
-        font-weight: 100;
-        font-family: Teko;
-        font-size: 48px;
-        line-height: 54px;
-        text-transform: uppercase;
-        letter-spacing: 1px;
-    }
-
-    h3 {
-        font-weight: 100;
-        font-family: Teko;
-        font-size: 28px;
-        line-height: 40px;
-        text-transform: uppercase;
-
-        margin: 60px 0 30px 0;
-    }
-
-    p {
-        color: #ddd;
-        font-size: 16px;
-        line-height: 30px;
-    }
-`;
-
-const HeaderSection = styled.section`
-    margin: 0 67px 0 74px;
-`;
-
-const MainSection = styled.section`
-    p {
-        margin-bottom: 30px;
-    }
-`;
-
-export default class Disclaimer extends React.PureComponent {
+export default class Disclaimer extends React.Component {
     render() {
+        const props = {
+            header: 'Disclaimer',
+            article:
+                `<p>
+                    Being in the mountains is dangerous, challenging
+                    but also unique and wonderful. The same is true
+                    when surfing the internet.
+                </p>
+                <p>
+                    Your safety is at the center of all of our works.
+                    All our Team here at a Agent is dedicated to create
+                    the best experience possible. Practicing safe code
+                    during the conference sessions, delivering pleasant
+                    experiences while traveling, at your stay or while
+                    going out with us, we want to make sure that you
+                    get back home safe.
+                </p>
+                <p>
+                    Even tough we use modern ad networks, current
+                    retargeting technology and latest hosting services
+                    we kindly ask you to do your best in supporting our
+                    effort of your safety. Please note that all our
+                    pictures are captured under creative commons
+                    license and might be used for further marketing.
+                </p>
+                <p>
+                    One thing we got to mention clearly: In case you
+                    get hurt, injured or killed Agent Conf, its
+                    Co-Organizers and StarsMedia IT Management KG can
+                    not take any responsibility since we only organize
+                    a couple of talks and got no influence on your
+                    driving skills, slopes or other conditions.
+                </p>
+                <p>
+                    Please note that the Photos on this site are
+                    captured by Nina Bröll, Christoph Blank,
+                    Matthias Rhomberg, Paul Turkowski,
+                    Unsplash Photographers and others.
+                </p>`,
+        };
+
         return (
-            <Page>
-                <HeaderImage />
-                <Main>
-                    <HeaderSection>
-                        <h2>Disclaimer</h2>
-                    </HeaderSection>
-                    <MainSection>
-                        <p>
-                            Being in the mountains is dangerous, challenging
-                            but also unique and wonderful. The same is true
-                            when surfing the internet.
-                        </p>
-                        <p>
-                            Your safety is at the center of all of our works.
-                            All our Team here at a Agent is dedicated to create
-                            the best experience possible. Practicing safe code
-                            during the conference sessions, delivering pleasant
-                            experiences while traveling, at your stay or while
-                            going out with us, we want to make sure that you
-                            get back home safe.
-                        </p>
-                        <p>
-                            Even tough we use modern ad networks, current
-                            retargeting technology and latest hosting services
-                            we kindly ask you to do your best in supporting our
-                            effort of your safety. Please note that all our
-                            pictures are captured under creative commons
-                            license and might be used for further marketing.
-                        </p>
-                        <p>
-                            One thing we got to mention clearly: In case you
-                            get hurt, injured or killed Agent Conf, its
-                            Co-Organizers and StarsMedia IT Management KG can
-                            not take any responsibility since we only organize
-                            a couple of talks and got no influence on your
-                            driving skills, slopes or other conditions.
-                        </p>
-                        <p>
-                            Please note that the Photos on this site are
-                            captured by Nina Bröll, Christoph Blank,
-                            Matthias Rhomberg, Paul Turkowski,
-                            Unsplash Photographers and others.
-                        </p>
-                    </MainSection>
-                </Main>
-            </Page>
+            <DefaultPage {...props} />
         );
     }
 }


### PR DESCRIPTION
This adds the [coc from of last years website](https://github.com/agentsh/agent17-website/blob/master/pages/coc.js).

Moving the "Templates" like the "DefaultPage" to an own component would allow us to easily prepare a single template for each corresponding template in Sulu, and use these in each page.